### PR TITLE
fix: remove 2>/dev/null that creates literal nul file on Windows

### DIFF
--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -46,9 +46,9 @@ node ../../scripts/detect.js . --thoroughness normal --compact --max 50
 
 **For diff scope** (only changed files):
 ```bash
-BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+BASE=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@' || echo "main")
 # Use newline-separated list to safely handle filenames with special chars
-git diff --name-only origin/${BASE}..HEAD 2>/dev/null | \
+git diff --name-only origin/${BASE}..HEAD | \
   xargs -d '\n' node ../../scripts/detect.js --thoroughness normal --compact
 ```
 


### PR DESCRIPTION
## Summary

- Removed `2>/dev/null` stderr redirects from SKILL.md bash commands (lines 49, 51)
- On Windows, when AI agents execute these via Node.js `child_process`, the redirect creates a literal file named `nul` (0 bytes) in the project directory instead of routing to the null device
- The redirects were unnecessary: `git symbolic-ref` already has an `|| echo "main"` fallback, and `git diff` stderr does not need suppression

## Context

Follow-up to agent-sh/agentsys#270 (Bug 1). Bug 2 (jscpd `--output NUL`) was fixed in agentsys PR #271.

## Test Plan

- [x] Verify no `2>/dev/null` remains in the repo
- [ ] Manual: run `/deslop` with diff scope on Windows, confirm no `nul` file created