### PR TITLE
docs: upgrade README from stub to full documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,119 @@
 # deslop
 
-AI slop cleanup with minimal diffs and behavior preservation
+Detect and remove AI-generated slop from codebases with certainty-based findings and safe auto-fixes.
+
+## Why
+
+AI coding tools leave behind debug statements, placeholder text, empty catch blocks, over-commented code, and dead abstractions. Manual cleanup is tedious and error-prone. deslop runs a 3-phase detection pipeline that categorizes every finding by certainty level - HIGH findings get auto-fixed, MEDIUM findings get flagged for review, and LOW findings are reported without action. Behavior is preserved. Diffs are minimal.
+
+**Use cases:**
+
+- Pre-PR hygiene - scan changed files before opening a pull request
+- Periodic repo maintenance - sweep the full codebase for accumulated slop
+- CI gate - fail on HIGH-certainty slop in changed files
 
 ## Installation
 
 ```bash
-# Claude Code
-claude mcp add-plugin agent-sh/deslop
-
-# Or install from marketplace
 agentsys install deslop
 ```
 
+## Quick Start
+
+```bash
+# Report slop findings (no changes made)
+/deslop
+
+# Auto-fix HIGH certainty findings
+/deslop apply
+
+# Scan only changed files in current branch
+/deslop report --scope=diff
+
+# Fix up to 10 findings in a specific directory
+/deslop apply src/ 10
+```
+
+## How It Works
+
+deslop uses a 3-phase detection pipeline with increasing analysis depth:
+
+**Phase 1 - Regex patterns (HIGH certainty).** Fast pattern matching for `console.log`, `print()`, `dbg!()`, TODO/FIXME markers, empty catch blocks, hardcoded secrets, trailing whitespace, and mixed indentation. These are safe to auto-fix.
+
+**Phase 2 - Multi-pass analyzers (MEDIUM certainty).** Structural analysis for doc-to-code ratio problems, verbose over-commenting, over-engineering, buzzword inflation, dead code after return/throw, and stub functions. These need human review.
+
+**Phase 3 - CLI tools (LOW certainty, optional).** Runs external tools when available - jscpd for duplication, madge for circular dependencies, eslint/pylint/clippy/golangci-lint for language-specific issues. Findings are flagged but not auto-fixed.
+
+**Thoroughness levels** control which phases run:
+
+| Level | Phases | Speed |
+|-------|--------|-------|
+| `quick` | Phase 1 only | Seconds |
+| `normal` (default) | Phase 1 + 2 | Seconds |
+| `deep` | Phase 1 + 2 + 3 | Depends on CLI tools |
+
+**Repo-intel integration** - when repo-intel data is available, deslop targets AI-written files first (`recent-ai` query) and escalates MEDIUM findings to HIGH for files with no test coverage (`test-gaps` query).
+
+## Certainty Levels
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| HIGH | Definitely slop - safe to remove | Auto-fixed in apply mode |
+| MEDIUM | Likely slop - needs context | Flagged for review |
+| LOW | Possible slop - context-dependent | Reported only |
+
 ## Usage
 
-```
+### Report Mode (default)
+
+```bash
 /deslop
+/deslop report --scope=diff
+/deslop report --thoroughness=deep
 ```
 
-## Keywords
+Outputs a prioritized table of findings with certainty levels and suggested fixes. No files are modified.
 
-`code-quality`, `cleanup`, `refactoring`, `maintenance`, `slop-detection`
+### Apply Mode
+
+```bash
+/deslop apply
+/deslop apply --scope=diff
+/deslop apply src/ 10
+```
+
+Auto-fixes all HIGH certainty findings, then runs the project's test suite. If tests fail, all changes are rolled back with `git restore .` and the failing fix is reported.
+
+### Scope Options
+
+- `all` (default) - scan entire codebase
+- `diff` - only files changed in current branch
+- `<path>` - specific directory or file
+
+### Thoroughness Options
+
+```bash
+/deslop --thoroughness=quick    # Phase 1 only
+/deslop --thoroughness=normal   # Phase 1 + 2 (default)
+/deslop --thoroughness=deep     # All phases
+```
+
+## Supported Languages
+
+JavaScript/TypeScript, Python, Rust, Go, Java/Kotlin, C/C++.
+
+## Requirements
+
+- Git (required for rollback safety)
+- Node.js
+- [agentsys](https://github.com/agent-sh/agentsys) runtime
+- For deep mode: jscpd, madge, eslint, pylint, clippy, or golangci-lint (optional, used when available)
+
+## Related Plugins
+
+- [next-task](https://github.com/agent-sh/next-task) - invokes deslop in Phase 8 pre-review gates
+- [enhance](https://github.com/agent-sh/enhance) - broader code quality analysis
+- [audit-project](https://github.com/agent-sh/audit-project) - multi-agent code review
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replace 27-line stub with full README (121 lines)
- Document 3-phase detection pipeline with certainty levels
- Thoroughness levels, scope options, supported languages
- Repo-intel integration for AI targeting and risk escalation

## Test plan
- [ ] README renders correctly on GitHub