### PR TITLE
chore: sync core lib and CLAUDE.md from agent-core

### DIFF
--- a/lib/binary/index.js
+++ b/lib/binary/index.js
@@ -1,0 +1,805 @@
+'use strict';
+
+/**
+ * Binary resolver for the agent-analyzer Rust binary.
+ *
+ * Handles lazy downloading and execution. Since Claude Code plugins have no
+ * postinstall hooks, the binary is downloaded at runtime on first use.
+ *
+ * Security hardening (2026-04-26 audit):
+ *   - Every release asset is verified against its `<asset>.sha256` sidecar
+ *     before extraction. A mismatch aborts with a clear message.
+ *   - Archives are extracted into an isolated tmpdir. Each entry path is
+ *     validated to reject absolute paths, Windows drive letters, and parent
+ *     traversal (`..`). The expected binary is then moved to the final
+ *     destination; everything else is discarded.
+ *   - The Windows zip path runs a PowerShell helper script via `-File` and
+ *     passes paths through environment variables, so PowerShell never
+ *     re-parses a command string (which broke on spaces/brackets). The
+ *     script validates every zip entry before extracting it and rejects
+ *     absolute, UNC, and parent-traversal entries.
+ *
+ * @module lib/binary
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const https = require('https');
+const cp = require('child_process');
+const crypto = require('crypto');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(cp.execFile);
+
+const { ANALYZER_MIN_VERSION, BINARY_NAME, GITHUB_REPO } = require('./version');
+
+const PLATFORM_MAP = {
+  'darwin-arm64': 'aarch64-apple-darwin',
+  'darwin-x64':   'x86_64-apple-darwin',
+  'linux-x64':    'x86_64-unknown-linux-gnu',
+  'linux-arm64':  'aarch64-unknown-linux-gnu',
+  'win32-x64':    'x86_64-pc-windows-msvc'
+};
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the expected path to the agent-analyzer binary.
+ * @returns {string}
+ */
+function getBinaryPath() {
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  return path.join(os.homedir(), '.agent-sh', 'bin', BINARY_NAME + ext);
+}
+
+/**
+ * Returns the Rust target triple for the current platform.
+ * @returns {string|null}
+ */
+function getPlatformKey() {
+  const key = process.platform + '-' + process.arch;
+  return PLATFORM_MAP[key] || null;
+}
+
+// ---------------------------------------------------------------------------
+// Version helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare a version string against a minimum requirement.
+ * @param {string} version
+ * @param {string} minVersion
+ * @returns {boolean}
+ */
+function meetsMinimumVersion(version, minVersion) {
+  if (!version) return false;
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return false;
+  const parts = match.slice(1).map(Number);
+  const req = minVersion.split('.').map(Number);
+  if (parts[0] > req[0]) return true;
+  if (parts[0] < req[0]) return false;
+  if (parts[1] > req[1]) return true;
+  if (parts[1] < req[1]) return false;
+  return parts[2] >= req[2];
+}
+
+/**
+ * Run the binary with --version and return the version string, or null on failure.
+ * @returns {string|null}
+ */
+function getVersion() {
+  const binPath = getBinaryPath();
+  if (!fs.existsSync(binPath)) return null;
+  try {
+    const out = cp.execFileSync(binPath, ['--version'], {
+      timeout: 5000,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true
+    });
+    const match = out.trim().match(/(\d+\.\d+\.\d+)/);
+    return match ? match[1] : out.trim();
+  } catch (e) {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Availability checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Sync check: returns true if the binary exists and meets the minimum version.
+ * Does NOT download.
+ * @returns {boolean}
+ */
+function isAvailable() {
+  const binPath = getBinaryPath();
+  if (!fs.existsSync(binPath)) return false;
+  const ver = getVersion();
+  return meetsMinimumVersion(ver, ANALYZER_MIN_VERSION);
+}
+
+/**
+ * Async check: returns true if the binary exists and meets the minimum version.
+ * Does NOT download.
+ * @returns {Promise<boolean>}
+ */
+async function isAvailableAsync() {
+  return isAvailable();
+}
+
+// ---------------------------------------------------------------------------
+// Download + checksum verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the GitHub release download URL.
+ * @param {string} ver
+ * @param {string} platformKey
+ * @returns {string}
+ */
+function buildDownloadUrl(ver, platformKey) {
+  const ext = process.platform === 'win32' ? '.zip' : '.tar.gz';
+  return 'https://github.com/' + GITHUB_REPO + '/releases/download/v' + ver + '/' + BINARY_NAME + '-' + platformKey + ext;
+}
+
+/**
+ * Download a URL to a Buffer, following up to 5 redirects.
+ * Supports GITHUB_TOKEN / GH_TOKEN for auth.
+ * @param {string} url
+ * @returns {Promise<Buffer>}
+ */
+function downloadToBuffer(url) {
+  return new Promise(function(resolve, reject) {
+    const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+    function request(reqUrl, redirectCount) {
+      if (redirectCount > 5) {
+        reject(new Error('Too many redirects fetching from ' + url));
+        return;
+      }
+      const headers = {
+        'User-Agent': 'agent-core/binary-resolver',
+        'Accept': 'application/octet-stream'
+      };
+      if (ghToken) headers['Authorization'] = 'Bearer ' + ghToken;
+
+      https.get(reqUrl, { headers: headers }, function(res) {
+        const sc = res.statusCode;
+        if (sc === 301 || sc === 302 || sc === 307 || sc === 308) {
+          res.resume();
+          request(res.headers.location, redirectCount + 1);
+          return;
+        }
+        if (sc !== 200) {
+          res.resume();
+          const hint = sc === 403 ? ' (rate limited - set GITHUB_TOKEN env var)' : '';
+          reject(new Error('HTTP ' + sc + hint + ' fetching ' + reqUrl));
+          return;
+        }
+        const chunks = [];
+        res.on('data', function(chunk) { chunks.push(chunk); });
+        res.on('end', function() { resolve(Buffer.concat(chunks)); });
+        res.on('error', reject);
+      }).on('error', reject);
+    }
+
+    request(url, 0);
+  });
+}
+
+/**
+ * Parse the leading 64-hex digest from a `.sha256` sidecar body.
+ * Tolerant of these formats (GNU coreutils + BSD `shasum`):
+ *   "<64-hex>\n"
+ *   "<64-hex>  <filename>\n"        (text mode, two-space separator)
+ *   "<64-hex>  *<filename>\n"       (binary mode, leading asterisk)
+ *   "<64-hex> <filename>\n"         (single-space variants)
+ * Throws if no valid digest is found.
+ * @param {string} body
+ * @returns {string} lower-cased 64-char hex digest
+ */
+function parseSha256Sidecar(body) {
+  if (typeof body !== 'string') body = String(body || '');
+  const match = body.trim().match(/^([A-Fa-f0-9]{64})\b/);
+  if (!match) {
+    throw new Error('Could not parse SHA-256 digest from sidecar body');
+  }
+  return match[1].toLowerCase();
+}
+
+/**
+ * Fetch and parse a `.sha256` sidecar next to an asset URL.
+ * @param {string} assetUrl full URL of the archive (not the sidecar)
+ * @returns {Promise<string>} lower-cased hex digest
+ */
+async function downloadSha256(assetUrl) {
+  const sidecarUrl = assetUrl + '.sha256';
+  const buf = await downloadToBuffer(sidecarUrl);
+  return parseSha256Sidecar(buf.toString('utf8'));
+}
+
+/**
+ * Compute the lower-case hex SHA-256 of a Buffer.
+ * @param {Buffer} buf
+ * @returns {string}
+ */
+function sha256Hex(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Verify a downloaded buffer against an expected hex digest.
+ * Throws with a security-focused message on mismatch.
+ * @param {Buffer} buf
+ * @param {string} expectedHex
+ * @param {string} filename user-facing name for the error message
+ */
+function verifySha256(buf, expectedHex, filename) {
+  const expected = String(expectedHex || '').toLowerCase();
+  const actual = sha256Hex(buf);
+  if (expected !== actual) {
+    throw new Error(
+      'SHA-256 verification failed for ' + filename + ': ' +
+      'expected ' + expected + ', got ' + actual + '. ' +
+      'This could indicate a tampered release. Do not extract.'
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Archive entry validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Reject archive entries with paths that could escape the extract directory.
+ * Rules:
+ *   - No absolute POSIX paths (leading `/`)
+ *   - No Windows absolute paths (drive letter like `C:\` or `C:/`)
+ *   - No UNC paths (`\\server\share`)
+ *   - No `..` as a path component
+ *   - No empty entry names
+ * @param {string} entry
+ * @throws {Error} on unsafe entry
+ */
+function assertSafeArchiveEntry(entry) {
+  if (!entry || typeof entry !== 'string') {
+    throw new Error('Refusing to extract archive with empty entry name');
+  }
+  const name = entry.replace(/\\/g, '/').trim();
+  if (name.length === 0) {
+    throw new Error('Refusing to extract archive with empty entry name');
+  }
+  if (name.startsWith('//')) {
+    throw new Error('Refusing to extract archive with UNC entry: ' + entry);
+  }
+  if (name.startsWith('/')) {
+    throw new Error('Refusing to extract archive with absolute entry: ' + entry);
+  }
+  if (/^[A-Za-z]:[\\/]/.test(entry)) {
+    throw new Error('Refusing to extract archive with Windows absolute entry: ' + entry);
+  }
+  const parts = name.split('/').filter(function(p) { return p.length > 0; });
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i] === '..') {
+      throw new Error('Refusing to extract archive with parent-traversal entry: ' + entry);
+    }
+  }
+}
+
+/**
+ * List the entries inside a tar.gz buffer by running `tar -tz` over stdin.
+ * Returns the raw list; caller is responsible for validating each entry.
+ * @param {Buffer} buf
+ * @returns {Promise<string[]>}
+ */
+function listTarGzEntries(buf) {
+  return new Promise(function(resolve, reject) {
+    const tar = cp.spawn('tar', ['-tz'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    tar.stdout.on('data', function(d) { stdout += d; });
+    tar.stderr.on('data', function(d) { stderr += d; });
+    tar.on('error', reject);
+    tar.on('close', function(code) {
+      if (code !== 0) {
+        reject(new Error('tar -tz listing failed (code ' + code + '): ' + stderr));
+        return;
+      }
+      const entries = stdout.split(/\r?\n/).filter(function(l) { return l.length > 0; });
+      resolve(entries);
+    });
+    tar.stdin.write(buf);
+    tar.stdin.end();
+  });
+}
+
+/**
+ * Verify that a path resolved from extraction lies inside a known root.
+ * Guards against symlinks and any surprise introduced by the OS extractor.
+ * @param {string} root
+ * @param {string} candidate
+ */
+function assertInsideRoot(root, candidate) {
+  const rootResolved = path.resolve(root) + path.sep;
+  const candResolved = path.resolve(candidate);
+  if (candResolved !== path.resolve(root) && !candResolved.startsWith(rootResolved)) {
+    throw new Error('Extracted path escapes extract root: ' + candidate);
+  }
+}
+
+/**
+ * Recursively walk a directory and return all file paths (not dirs).
+ * Throws if any symlink is encountered (defense in depth: no surprise escapes).
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function walkFiles(dir) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    const st = fs.lstatSync(cur);
+    if (st.isSymbolicLink()) {
+      throw new Error('Refusing to follow symlink produced by extractor: ' + cur);
+    }
+    if (st.isDirectory()) {
+      const names = fs.readdirSync(cur);
+      for (let i = 0; i < names.length; i++) {
+        stack.push(path.join(cur, names[i]));
+      }
+    } else if (st.isFile()) {
+      out.push(cur);
+    }
+  }
+  return out;
+}
+
+/**
+ * Remove a directory tree, tolerating already-missing paths.
+ * @param {string} dir
+ */
+function rmrf(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (e) {
+    /* ignore */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a tar.gz buffer into a scratch directory, validating entries first.
+ * Returns the scratch directory; caller is responsible for moving files out
+ * and calling rmrf() on it.
+ * @param {Buffer} buf
+ * @returns {Promise<string>} scratch dir
+ */
+async function extractTarGzToScratch(buf) {
+  const entries = await listTarGzEntries(buf);
+  for (let i = 0; i < entries.length; i++) {
+    assertSafeArchiveEntry(entries[i]);
+  }
+
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-analyzer-tar-'));
+
+  try {
+    await new Promise(function(resolve, reject) {
+      const tar = cp.spawn('tar', ['xz', '-C', scratch], { stdio: ['pipe', 'pipe', 'pipe'] });
+      let stderr = '';
+      tar.stderr.on('data', function(d) { stderr += d; });
+      tar.on('error', reject);
+      tar.on('close', function(code) {
+        if (code !== 0) {
+          reject(new Error('tar extraction failed (code ' + code + '): ' + stderr));
+        } else {
+          resolve();
+        }
+      });
+      tar.stdin.write(buf);
+      tar.stdin.end();
+    });
+
+    // Defense in depth: reject any symlink or non-regular entry the OS
+    // extractor may have created, and confirm every file resolves inside
+    // scratch.
+    const files = walkFiles(scratch);
+    for (let i = 0; i < files.length; i++) {
+      assertInsideRoot(scratch, files[i]);
+    }
+  } catch (err) {
+    rmrf(scratch);
+    throw err;
+  }
+
+  return scratch;
+}
+
+/**
+ * PowerShell script body that validates and extracts a zip entry-by-entry
+ * using .NET's System.IO.Compression.ZipFile. Paths and output dir are read
+ * from environment variables (`SRC_ZIP`, `DEST_DIR`) so no argument parsing
+ * can split on spaces, wildcards, or quotes.
+ *
+ * Rejects:
+ *   - Absolute entry names (POSIX `/`, Windows `C:\`)
+ *   - UNC entry names (`\\server\share`)
+ *   - Any `..` path component
+ *   - Resolved paths that escape the destination directory
+ *
+ * On any validation failure the script writes to stderr and exits with a
+ * non-zero status; nothing is extracted.
+ */
+const EXTRACT_ZIP_PS1 = [
+  '$ErrorActionPreference = "Stop"',
+  '$src  = $env:SRC_ZIP',
+  '$dest = $env:DEST_DIR',
+  'if ([string]::IsNullOrEmpty($src) -or [string]::IsNullOrEmpty($dest)) {',
+  '  [Console]::Error.WriteLine("SRC_ZIP and DEST_DIR must both be set"); exit 2',
+  '}',
+  'Add-Type -AssemblyName System.IO.Compression.FileSystem',
+  '$destFull = [System.IO.Path]::GetFullPath($dest)',
+  'if (-not $destFull.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {',
+  '  $destFull = $destFull + [System.IO.Path]::DirectorySeparatorChar',
+  '}',
+  '$zip = [System.IO.Compression.ZipFile]::OpenRead($src)',
+  'try {',
+  '  foreach ($entry in $zip.Entries) {',
+  '    $name = $entry.FullName',
+  '    if ([string]::IsNullOrEmpty($name)) { continue }',
+  '    $norm = $name -replace "\\\\","/"',
+  '    if ($norm.StartsWith("/") -or $norm.StartsWith("//")) {',
+  '      [Console]::Error.WriteLine("Refusing absolute/UNC entry: " + $name); exit 3',
+  '    }',
+  '    if ($name -match "^[A-Za-z]:[\\\\/]") {',
+  '      [Console]::Error.WriteLine("Refusing Windows-absolute entry: " + $name); exit 3',
+  '    }',
+  '    foreach ($part in ($norm -split "/")) {',
+  '      if ($part -eq "..") {',
+  '        [Console]::Error.WriteLine("Refusing parent-traversal entry: " + $name); exit 3',
+  '      }',
+  '    }',
+  '    $target = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($destFull, $norm))',
+  '    if (-not $target.StartsWith($destFull, [System.StringComparison]::OrdinalIgnoreCase)) {',
+  '      [Console]::Error.WriteLine("Entry escapes destination: " + $name); exit 3',
+  '    }',
+  '    if ($entry.FullName.EndsWith("/")) {',
+  '      [System.IO.Directory]::CreateDirectory($target) | Out-Null',
+  '    } else {',
+  '      $parent = [System.IO.Path]::GetDirectoryName($target)',
+  '      if ($parent) { [System.IO.Directory]::CreateDirectory($parent) | Out-Null }',
+  '      [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target, $true)',
+  '    }',
+  '  }',
+  '} finally {',
+  '  $zip.Dispose()',
+  '}'
+].join('\r\n');
+
+/**
+ * Extract a zip buffer into a scratch directory.
+ *
+ * The extraction runs a PowerShell helper script via `-File` so PowerShell
+ * never re-parses a command string (which would break on paths containing
+ * spaces or brackets). The script reads the zip and destination paths from
+ * environment variables, validates every entry's path before extracting, and
+ * writes files individually using .NET's ZipFile APIs.
+ *
+ * After extraction, `walkFiles` re-checks the tree and rejects any symlink
+ * or junction that might have been created.
+ *
+ * @param {Buffer} buf
+ * @returns {Promise<string>} scratch dir
+ */
+async function extractZipToScratch(buf) {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-analyzer-zip-'));
+  const tmpZip = path.join(scratch, '__archive.zip');
+  const scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-analyzer-ps-'));
+  const scriptPath = path.join(scriptDir, 'extract.ps1');
+
+  try {
+    fs.writeFileSync(tmpZip, buf);
+    fs.writeFileSync(scriptPath, EXTRACT_ZIP_PS1, 'utf8');
+
+    await new Promise(function(resolve, reject) {
+      const child = cp.execFile(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-ExecutionPolicy', 'Bypass',
+          '-File', scriptPath
+        ],
+        {
+          windowsHide: true,
+          env: Object.assign({}, process.env, {
+            SRC_ZIP: tmpZip,
+            DEST_DIR: scratch
+          })
+        },
+        function(err, _stdout, stderr) {
+          if (err) {
+            reject(new Error('zip extraction failed: ' + (stderr || err.message)));
+          } else {
+            resolve();
+          }
+        }
+      );
+      // Do not write to stdin; the script reads from env.
+      if (child.stdin) child.stdin.end();
+    });
+
+    try { fs.unlinkSync(tmpZip); } catch (e) { /* ignore */ }
+
+    // Defense in depth: walkFiles() throws on any symlink/junction. Also
+    // confirm every file resolves inside scratch.
+    const files = walkFiles(scratch);
+    for (let i = 0; i < files.length; i++) {
+      assertInsideRoot(scratch, files[i]);
+    }
+  } catch (err) {
+    rmrf(scratch);
+    throw err;
+  } finally {
+    rmrf(scriptDir);
+  }
+
+  return scratch;
+}
+
+/**
+ * Find the expected binary inside a scratch directory (recursive search).
+ * @param {string} scratch
+ * @param {string} binaryBaseName e.g. `agent-analyzer` or `agent-analyzer.exe`
+ * @returns {string|null} absolute path, or null if not found
+ */
+function findBinaryInScratch(scratch, binaryBaseName) {
+  const files = walkFiles(scratch);
+  for (let i = 0; i < files.length; i++) {
+    if (path.basename(files[i]) === binaryBaseName) {
+      assertInsideRoot(scratch, files[i]);
+      return files[i];
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Download + install
+// ---------------------------------------------------------------------------
+
+/**
+ * Download and install the binary for the current platform into ~/.agent-sh/bin/.
+ * @param {string} ver
+ * @param {Object} [options]
+ * @param {boolean} [options.skipChecksum=false] LOCAL DEV ONLY. Skips the
+ *   `.sha256` sidecar fetch and verification. NEVER set this in production.
+ * @returns {Promise<string>} path to the installed binary
+ */
+async function downloadBinary(ver, options) {
+  const opts = options || {};
+  const skipChecksum = opts.skipChecksum === true;
+
+  const platformKey = getPlatformKey();
+  if (!platformKey) {
+    throw new Error(
+      'Unsupported platform: ' + process.platform + '-' + process.arch + '. ' +
+      'Supported platforms: ' + Object.keys(PLATFORM_MAP).join(', ')
+    );
+  }
+
+  const url = buildDownloadUrl(ver, platformKey);
+  const filename = url.substring(url.lastIndexOf('/') + 1);
+  process.stderr.write('Downloading ' + BINARY_NAME + ' v' + ver + ' for ' + platformKey + '...\n');
+
+  const binPath = getBinaryPath();
+  const binDir = path.dirname(binPath);
+  fs.mkdirSync(binDir, { recursive: true });
+
+  // --- 1. Fetch archive bytes --------------------------------------------
+  let buf;
+  try {
+    buf = await downloadToBuffer(url);
+  } catch (err) {
+    throw new Error(
+      'Failed to download ' + BINARY_NAME + ':\n' +
+      '  URL: ' + url + '\n' +
+      '  Error: ' + err.message + '\n\n' +
+      'To install manually:\n' +
+      '  1. Download: ' + url + '\n' +
+      '  2. Extract the binary to: ' + binDir + '\n' +
+      '  3. Ensure it is named: ' + path.basename(binPath)
+    );
+  }
+
+  // --- 2. Verify SHA-256 sidecar -----------------------------------------
+  if (skipChecksum) {
+    process.stderr.write(
+      '[WARN] skipChecksum=true - SHA-256 verification disabled. ' +
+      'This is LOCAL DEV ONLY and MUST NOT be used in production.\n'
+    );
+  } else {
+    let expected;
+    try {
+      expected = await downloadSha256(url);
+    } catch (err) {
+      throw new Error(
+        'Failed to fetch SHA-256 sidecar for ' + filename + ':\n' +
+        '  URL: ' + url + '.sha256\n' +
+        '  Error: ' + err.message + '\n\n' +
+        'The release may be missing its checksum file. Refusing to install ' +
+        'an unverified binary. If this is a legacy release without sidecars, ' +
+        'pass { skipChecksum: true } to downloadBinary() (LOCAL DEV ONLY).'
+      );
+    }
+    verifySha256(buf, expected, filename);
+  }
+
+  // --- 3. Extract to isolated scratch dir + validate entries -------------
+  const binaryBaseName = path.basename(binPath);
+  let scratch;
+  try {
+    if (process.platform === 'win32') {
+      scratch = await extractZipToScratch(buf);
+    } else {
+      scratch = await extractTarGzToScratch(buf);
+    }
+
+    // --- 4. Locate the expected binary inside scratch --------------------
+    const extractedBin = findBinaryInScratch(scratch, binaryBaseName);
+    if (!extractedBin) {
+      throw new Error(
+        'Expected binary "' + binaryBaseName + '" not found inside archive ' +
+        filename + '. Archive layout may have changed.'
+      );
+    }
+
+    // --- 5. Move ONLY the expected binary to its final location ----------
+    // copyFileSync so cross-device moves work. scratch is rmrf'd in finally.
+    fs.copyFileSync(extractedBin, binPath);
+  } finally {
+    if (scratch) rmrf(scratch);
+  }
+
+  if (process.platform !== 'win32') {
+    fs.chmodSync(binPath, 0o755);
+  }
+
+  const installedVer = getVersion();
+  if (!installedVer) {
+    throw new Error(
+      BINARY_NAME + ' was downloaded to ' + binPath + ' but could not be executed. ' +
+      'Check the file is a valid binary for this platform.'
+    );
+  }
+
+  return binPath;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the binary exists and meets the minimum version. Downloads if needed.
+ * @param {Object} [options]
+ * @param {string} [options.version]
+ * @param {boolean} [options.skipChecksum=false] LOCAL DEV ONLY.
+ * @returns {Promise<string>}
+ */
+async function ensureBinary(options) {
+  const opts = options || {};
+  const targetVer = opts.version || ANALYZER_MIN_VERSION;
+  const binPath = getBinaryPath();
+
+  if (fs.existsSync(binPath)) {
+    const ver = getVersion();
+    if (meetsMinimumVersion(ver, ANALYZER_MIN_VERSION)) {
+      return binPath;
+    }
+  }
+
+  return downloadBinary(targetVer, { skipChecksum: opts.skipChecksum === true });
+}
+
+/**
+ * Sync version of ensureBinary. Downloads if needed via a child node process.
+ * Prefer ensureBinary() unless a sync API is strictly required.
+ * @param {Object} [options]
+ * @param {string} [options.version]
+ * @param {boolean} [options.skipChecksum=false] LOCAL DEV ONLY.
+ * @returns {string}
+ */
+function ensureBinarySync(options) {
+  const binPath = getBinaryPath();
+
+  if (fs.existsSync(binPath)) {
+    const ver = getVersion();
+    if (meetsMinimumVersion(ver, ANALYZER_MIN_VERSION)) {
+      return binPath;
+    }
+  }
+
+  const targetVer = (options && options.version) || ANALYZER_MIN_VERSION;
+  const skipChecksum = !!(options && options.skipChecksum);
+  const selfPath = __filename;
+  const helperLines = [
+    'var b = require(' + JSON.stringify(selfPath) + ');',
+    'b.ensureBinary({ version: ' + JSON.stringify(targetVer) +
+      ', skipChecksum: ' + JSON.stringify(skipChecksum) + ' })',
+    '  .then(function(p) { process.stdout.write(p); })',
+    '  .catch(function(e) { process.stderr.write(e.message); process.exit(1); });'
+  ];
+
+  try {
+    const result = cp.execFileSync(process.execPath, ['-e', helperLines.join('\n')], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'inherit'],
+      timeout: 120000
+    });
+    return result.trim() || binPath;
+  } catch (err) {
+    throw new Error('Failed to ensure binary (sync): ' + err.message);
+  }
+}
+
+/**
+ * Run agent-analyzer with the given arguments (sync). Downloads binary if needed.
+ * @param {string[]} args
+ * @param {Object} [options]
+ * @returns {string}
+ */
+function runAnalyzer(args, options) {
+  const binPath = ensureBinarySync();
+  const opts = Object.assign({ encoding: 'utf8', windowsHide: true }, options);
+  if (!opts.stdio) opts.stdio = ['pipe', 'pipe', 'pipe'];
+  const result = cp.execFileSync(binPath, args, opts);
+  return typeof result === 'string' ? result : result.toString('utf8');
+}
+
+/**
+ * Run agent-analyzer with the given arguments asynchronously. Downloads binary if needed.
+ * @param {string[]} args
+ * @param {Object} [options]
+ * @returns {Promise<string>}
+ */
+async function runAnalyzerAsync(args, options) {
+  const binPath = await ensureBinary();
+  const opts = Object.assign({ encoding: 'utf8', windowsHide: true }, options);
+  const result = await execFileAsync(binPath, args, opts);
+  return result.stdout;
+}
+
+module.exports = {
+  ensureBinary,
+  ensureBinarySync,
+  runAnalyzer,
+  runAnalyzerAsync,
+  getBinaryPath,
+  getVersion,
+  getPlatformKey,
+  isAvailable,
+  isAvailableAsync,
+  meetsMinimumVersion,
+  buildDownloadUrl,
+  PLATFORM_MAP,
+  // Exported for tests + advanced consumers
+  parseSha256Sidecar,
+  verifySha256,
+  sha256Hex,
+  assertSafeArchiveEntry,
+  assertInsideRoot,
+  downloadBinary,
+  // Exported for tests only
+  extractTarGzToScratch,
+  extractZipToScratch,
+  _EXTRACT_ZIP_PS1: EXTRACT_ZIP_PS1
+};

--- a/lib/binary/index.test.js
+++ b/lib/binary/index.test.js
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Tests for the security-hardened binary downloader.
+ *
+ * Focus:
+ *   - SHA-256 sidecar parsing and verification
+ *   - Archive entry path validation (absolute, drive letter, parent traversal)
+ *   - Scratch-root escape detection
+ *   - Happy-path extraction flow via a real gzipped tar built in-test
+ *
+ * These tests do NOT hit the network or install any binary.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const zlib = require('node:zlib');
+const cp = require('node:child_process');
+
+const mod = require('./index.js');
+
+// ---------------------------------------------------------------------------
+// Helpers: build a minimal gzipped USTAR archive in memory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a single USTAR tar block for a regular file with the given name and
+ * contents. Returns 512-byte header + padded data blocks.
+ */
+function tarBlock(name, contents) {
+  const data = Buffer.from(contents, 'utf8');
+  const header = Buffer.alloc(512, 0);
+
+  // Name field (0-99): ASCII, NUL-terminated if shorter
+  header.write(name, 0, Math.min(name.length, 100), 'utf8');
+  // Mode (100-107): "0000644\0"
+  header.write('0000644\0', 100, 8, 'ascii');
+  // UID (108-115), GID (116-123): "0000000\0"
+  header.write('0000000\0', 108, 8, 'ascii');
+  header.write('0000000\0', 116, 8, 'ascii');
+  // Size (124-135): octal, 11 digits + NUL
+  const sizeOctal = data.length.toString(8).padStart(11, '0') + '\0';
+  header.write(sizeOctal, 124, 12, 'ascii');
+  // Mtime (136-147): "00000000000\0"
+  header.write('00000000000\0', 136, 12, 'ascii');
+  // Checksum field (148-155): fill with spaces for checksum calculation
+  header.write('        ', 148, 8, 'ascii');
+  // Typeflag (156): '0' = regular file
+  header.write('0', 156, 1, 'ascii');
+  // Magic + version (257-264): "ustar\0" + "00"
+  header.write('ustar\0', 257, 6, 'ascii');
+  header.write('00', 263, 2, 'ascii');
+
+  // Compute checksum: unsigned sum of all 512 header bytes
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += header[i];
+  const chkOctal = sum.toString(8).padStart(6, '0') + '\0 ';
+  header.write(chkOctal, 148, 8, 'ascii');
+
+  // Pad data to 512-byte multiple
+  const padLen = (512 - (data.length % 512)) % 512;
+  const padded = Buffer.concat([data, Buffer.alloc(padLen, 0)]);
+
+  return Buffer.concat([header, padded]);
+}
+
+function buildTarGz(files) {
+  const blocks = files.map(function(f) { return tarBlock(f.name, f.contents); });
+  // Two empty 512-byte blocks terminate the archive
+  const terminator = Buffer.alloc(1024, 0);
+  const tar = Buffer.concat(blocks.concat([terminator]));
+  return zlib.gzipSync(tar);
+}
+
+function hasSystemTar() {
+  try {
+    cp.execFileSync('tar', ['--version'], { stdio: 'ignore', timeout: 3000 });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseSha256Sidecar
+// ---------------------------------------------------------------------------
+
+describe('parseSha256Sidecar', function() {
+  it('parses a bare 64-hex digest', function() {
+    const hex = 'a'.repeat(64);
+    assert.equal(mod.parseSha256Sidecar(hex + '\n'), hex);
+  });
+
+  it('parses GNU coreutils format "<hex>  <name>"', function() {
+    const hex = '0123456789abcdef'.repeat(4);
+    const body = hex + '  agent-analyzer-x86_64-unknown-linux-gnu.tar.gz\n';
+    assert.equal(mod.parseSha256Sidecar(body), hex);
+  });
+
+  it('parses BSD binary-mode format "<hex>  *<name>"', function() {
+    const hex = 'f'.repeat(64);
+    const body = hex + '  *agent-analyzer.zip\n';
+    assert.equal(mod.parseSha256Sidecar(body), hex);
+  });
+
+  it('lower-cases an upper-case digest', function() {
+    const hex = 'A'.repeat(64);
+    assert.equal(mod.parseSha256Sidecar(hex), 'a'.repeat(64));
+  });
+
+  it('throws on missing digest', function() {
+    assert.throws(function() { mod.parseSha256Sidecar('not a digest'); },
+      /Could not parse SHA-256 digest/);
+  });
+
+  it('throws on short hex', function() {
+    assert.throws(function() { mod.parseSha256Sidecar('abc123'); },
+      /Could not parse SHA-256 digest/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifySha256
+// ---------------------------------------------------------------------------
+
+describe('verifySha256', function() {
+  it('accepts a matching digest', function() {
+    const buf = Buffer.from('hello world', 'utf8');
+    const hex = crypto.createHash('sha256').update(buf).digest('hex');
+    assert.doesNotThrow(function() { mod.verifySha256(buf, hex, 'test.bin'); });
+  });
+
+  it('accepts a matching digest case-insensitively', function() {
+    const buf = Buffer.from('hello world', 'utf8');
+    const hex = crypto.createHash('sha256').update(buf).digest('hex').toUpperCase();
+    assert.doesNotThrow(function() { mod.verifySha256(buf, hex, 'test.bin'); });
+  });
+
+  it('throws with tamper-framed message on mismatch', function() {
+    const buf = Buffer.from('hello world', 'utf8');
+    const wrong = '0'.repeat(64);
+    assert.throws(
+      function() { mod.verifySha256(buf, wrong, 'agent-analyzer.tar.gz'); },
+      function(err) {
+        assert.match(err.message, /SHA-256 verification failed for agent-analyzer\.tar\.gz/);
+        assert.match(err.message, /expected 0{64}/);
+        assert.match(err.message, /tampered release/);
+        assert.match(err.message, /Do not extract/);
+        return true;
+      }
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertSafeArchiveEntry
+// ---------------------------------------------------------------------------
+
+describe('assertSafeArchiveEntry', function() {
+  it('accepts a normal relative entry', function() {
+    assert.doesNotThrow(function() { mod.assertSafeArchiveEntry('agent-analyzer'); });
+    assert.doesNotThrow(function() { mod.assertSafeArchiveEntry('bin/agent-analyzer'); });
+    assert.doesNotThrow(function() { mod.assertSafeArchiveEntry('dir/sub/file.txt'); });
+  });
+
+  it('rejects parent-traversal entry', function() {
+    assert.throws(function() { mod.assertSafeArchiveEntry('../evil.exe'); },
+      /parent-traversal/);
+    assert.throws(function() { mod.assertSafeArchiveEntry('foo/../../evil'); },
+      /parent-traversal/);
+    assert.throws(function() { mod.assertSafeArchiveEntry('a/b/..'); },
+      /parent-traversal/);
+  });
+
+  it('rejects POSIX absolute path', function() {
+    assert.throws(function() { mod.assertSafeArchiveEntry('/etc/passwd'); },
+      /absolute entry/);
+  });
+
+  it('rejects Windows drive-letter path', function() {
+    assert.throws(function() { mod.assertSafeArchiveEntry('C:\\Windows\\evil.exe'); },
+      /Windows absolute entry/);
+    assert.throws(function() { mod.assertSafeArchiveEntry('D:/foo'); },
+      /Windows absolute entry/);
+  });
+
+  it('rejects UNC path', function() {
+    assert.throws(function() { mod.assertSafeArchiveEntry('//server/share/evil'); },
+      /UNC entry/);
+  });
+
+  it('rejects empty entry', function() {
+    assert.throws(function() { mod.assertSafeArchiveEntry(''); },
+      /empty entry/);
+    assert.throws(function() { mod.assertSafeArchiveEntry(null); },
+      /empty entry/);
+  });
+
+  it('rejects backslash-form parent traversal', function() {
+    // Windows-style separator in tar entries should still be caught
+    assert.throws(function() { mod.assertSafeArchiveEntry('foo\\..\\bar'); },
+      /parent-traversal/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertInsideRoot
+// ---------------------------------------------------------------------------
+
+describe('assertInsideRoot', function() {
+  it('accepts a path inside root', function() {
+    const root = os.tmpdir();
+    const inside = path.join(root, 'a', 'b', 'c');
+    assert.doesNotThrow(function() { mod.assertInsideRoot(root, inside); });
+  });
+
+  it('rejects a path that escapes root via ..', function() {
+    const root = path.join(os.tmpdir(), 'root');
+    const escape = path.join(root, '..', 'outside');
+    assert.throws(function() { mod.assertInsideRoot(root, escape); },
+      /escapes extract root/);
+  });
+
+  it('rejects a sibling directory that shares a prefix', function() {
+    // /tmp/rootX should not be considered inside /tmp/root
+    const root = path.join(os.tmpdir(), 'root');
+    const sibling = path.join(os.tmpdir(), 'rootX', 'file');
+    assert.throws(function() { mod.assertInsideRoot(root, sibling); },
+      /escapes extract root/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy-path: synthetic tar.gz extracts and yields the expected binary
+// ---------------------------------------------------------------------------
+
+describe('synthetic tar.gz extraction (integration-lite)', function() {
+  it('extracts a simple tar containing agent-analyzer', { skip: !hasSystemTar() }, async function() {
+    const targz = buildTarGz([
+      { name: 'agent-analyzer', contents: '#!/bin/sh\necho ok\n' },
+      { name: 'README.md', contents: 'hi\n' }
+    ]);
+
+    // We test the internal flow by re-requiring and poking at the private
+    // helpers we export for tests. Use the exported downloadBinary? That
+    // would hit the network. Instead, build a scratch dir using the tar
+    // helpers directly.
+    //
+    // The safest public-surface test: assert that assertSafeArchiveEntry
+    // passes for each entry in a clean archive, AND that a synthetic tar
+    // built with only "agent-analyzer" + "README.md" round-trips via the
+    // system tar into a scratch dir.
+
+    // List entries via the same mechanism downloadBinary uses:
+    const tar = cp.spawnSync('tar', ['-tz'], { input: targz });
+    assert.equal(tar.status, 0, 'tar -tz should succeed on synthetic archive');
+    const entries = tar.stdout.toString('utf8').split(/\r?\n/).filter(Boolean);
+    assert.deepEqual(entries.sort(), ['README.md', 'agent-analyzer']);
+    for (const e of entries) {
+      assert.doesNotThrow(function() { mod.assertSafeArchiveEntry(e); });
+    }
+
+    // Now actually extract into a scratch dir and confirm the binary lands.
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-analyzer-test-'));
+    try {
+      const tarDest = process.platform === 'win32' ? scratch.replace(/\\/g, '/') : scratch;
+      const ex = cp.spawnSync('tar', ['xz', '-C', tarDest], { input: targz });
+      assert.equal(ex.status, 0, 'tar extract stderr: ' + (ex.stderr && ex.stderr.toString()));
+      const landed = path.join(scratch, 'agent-analyzer');
+      assert.ok(fs.existsSync(landed), 'extracted binary should exist');
+      assert.doesNotThrow(function() { mod.assertInsideRoot(scratch, landed); });
+    } finally {
+      fs.rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malicious archives: traversal + absolute paths are rejected BEFORE extract
+// ---------------------------------------------------------------------------
+
+describe('malicious tar.gz entries are rejected', function() {
+  it('rejects ../evil.exe before extraction', { skip: !hasSystemTar() }, function() {
+    const targz = buildTarGz([
+      { name: '../evil.exe', contents: 'pwned\n' }
+    ]);
+    const tar = cp.spawnSync('tar', ['-tz'], { input: targz });
+    assert.equal(tar.status, 0);
+    const entries = tar.stdout.toString('utf8').split(/\r?\n/).filter(Boolean);
+    assert.ok(entries.length > 0);
+    // The downloader loops entries and calls assertSafeArchiveEntry on each.
+    assert.throws(function() {
+      for (const e of entries) mod.assertSafeArchiveEntry(e);
+    }, /parent-traversal/);
+  });
+
+  it('rejects an absolute-path entry before extraction', { skip: !hasSystemTar() }, function() {
+    const targz = buildTarGz([
+      { name: '/etc/cron.d/backdoor', contents: 'pwn\n' }
+    ]);
+    const tar = cp.spawnSync('tar', ['-tz'], { input: targz });
+    assert.equal(tar.status, 0);
+    const entries = tar.stdout.toString('utf8').split(/\r?\n/).filter(Boolean);
+    assert.ok(entries.length > 0);
+    assert.throws(function() {
+      for (const e of entries) mod.assertSafeArchiveEntry(e);
+    }, /absolute entry/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public API surface has not regressed
+// ---------------------------------------------------------------------------
+
+describe('public API surface', function() {
+  it('exports the same top-level functions as before, plus new helpers', function() {
+    const expected = [
+      'ensureBinary', 'ensureBinarySync', 'runAnalyzer', 'runAnalyzerAsync',
+      'getBinaryPath', 'getVersion', 'getPlatformKey', 'isAvailable',
+      'isAvailableAsync', 'meetsMinimumVersion', 'buildDownloadUrl',
+      'PLATFORM_MAP',
+      // New (non-breaking additions)
+      'parseSha256Sidecar', 'verifySha256', 'sha256Hex',
+      'assertSafeArchiveEntry', 'assertInsideRoot', 'downloadBinary'
+    ];
+    for (const name of expected) {
+      assert.ok(name in mod, 'expected export: ' + name);
+    }
+  });
+
+  it('ensureBinary still accepts { version } without breaking', function() {
+    // Smoke-check: the function is callable without exploding on typecheck.
+    assert.equal(typeof mod.ensureBinary, 'function');
+    assert.equal(mod.ensureBinary.length, 1); // single optional [options]
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scratch cleanup: extractors must not leak scratch dirs on failure
+// ---------------------------------------------------------------------------
+
+describe('extractTarGzToScratch cleans up scratch on failure', function() {
+  it('rmrfs scratch when tar exits non-zero', { skip: !hasSystemTar() || process.platform === 'win32' }, async function() {
+    // Build a tar.gz whose entries look clean to the pre-validator but whose
+    // payload is corrupt. The quickest way: gzip random bytes. `tar -tz`
+    // will fail to list, so we instead pass a valid listing by monkey-patching.
+    // Simpler path: build a valid tar.gz, then snapshot tmpdir, invoke
+    // extractTarGzToScratch with a buffer whose listing succeeds but whose
+    // extraction fails because we truncate it mid-block.
+    const full = buildTarGz([{ name: 'agent-analyzer', contents: 'x'.repeat(2048) }]);
+    // Truncate to 512 bytes - `tar -tz` will fail BEFORE scratch is created,
+    // so this doesn't test the cleanup path. Instead, make listing succeed
+    // but extraction fail: keep the gzip header + first block, drop the rest.
+    // We take: full gzip of [header + small data + truncated].
+    // Simpler: run listing on `full`, then pass a corrupt buffer to the
+    // extractor after capturing entries. Since we can't intercept listing,
+    // we instead wrap extractTarGzToScratch in a controlled failure by
+    // giving it a buffer that lists but fails on extract. Practical trick:
+    // pass `full` concatenated with garbage, then check that tar rejects.
+    //
+    // Realistic failure: empty buffer. Both listing and extract will fail;
+    // extractTarGzToScratch should throw during listing (before scratch is
+    // made), so scratch is never created. That already proves no leak.
+    const before = fs.readdirSync(os.tmpdir()).filter(function(n) {
+      return n.startsWith('agent-analyzer-tar-');
+    });
+    await assert.rejects(function() {
+      return mod.extractTarGzToScratch(Buffer.alloc(0));
+    });
+    const after = fs.readdirSync(os.tmpdir()).filter(function(n) {
+      return n.startsWith('agent-analyzer-tar-');
+    });
+    // No new scratch dirs should have been left behind.
+    assert.deepEqual(after.sort(), before.sort(),
+      'extractTarGzToScratch must not leak scratch dirs on failure');
+    void full; // keep reference so test helper isn't tree-shaken conceptually
+  });
+
+  it('rejects symlinks produced by extractor via walkFiles', { skip: !hasSystemTar() || process.platform === 'win32' }, async function() {
+    // Build a tar that contains a symlink entry. Use the USTAR typeflag '2'.
+    function tarSymlinkBlock(name, linkname) {
+      const header = Buffer.alloc(512, 0);
+      header.write(name, 0, Math.min(name.length, 100), 'utf8');
+      header.write('0000777\0', 100, 8, 'ascii');
+      header.write('0000000\0', 108, 8, 'ascii');
+      header.write('0000000\0', 116, 8, 'ascii');
+      header.write('00000000000\0', 124, 12, 'ascii'); // size 0
+      header.write('00000000000\0', 136, 12, 'ascii');
+      header.write('        ', 148, 8, 'ascii');
+      header.write('2', 156, 1, 'ascii'); // symlink
+      header.write(linkname, 157, Math.min(linkname.length, 100), 'utf8');
+      header.write('ustar\0', 257, 6, 'ascii');
+      header.write('00', 263, 2, 'ascii');
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += header[i];
+      const chkOctal = sum.toString(8).padStart(6, '0') + '\0 ';
+      header.write(chkOctal, 148, 8, 'ascii');
+      return header;
+    }
+    const terminator = Buffer.alloc(1024, 0);
+    const tar = Buffer.concat([
+      tarSymlinkBlock('agent-analyzer', '/etc/passwd'),
+      terminator
+    ]);
+    const targz = zlib.gzipSync(tar);
+
+    const before = fs.readdirSync(os.tmpdir()).filter(function(n) {
+      return n.startsWith('agent-analyzer-tar-');
+    });
+    await assert.rejects(function() {
+      return mod.extractTarGzToScratch(targz);
+    }, /symlink/);
+    const after = fs.readdirSync(os.tmpdir()).filter(function(n) {
+      return n.startsWith('agent-analyzer-tar-');
+    });
+    assert.deepEqual(after.sort(), before.sort(),
+      'scratch dir must be cleaned up after symlink rejection');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PowerShell helper script is structurally safe
+// ---------------------------------------------------------------------------
+
+describe('PowerShell extract script', function() {
+  it('reads paths from environment, not from argv', function() {
+    const src = mod._EXTRACT_ZIP_PS1;
+    assert.match(src, /\$env:SRC_ZIP/,
+      'script must read zip path from SRC_ZIP env var');
+    assert.match(src, /\$env:DEST_DIR/,
+      'script must read destination from DEST_DIR env var');
+  });
+
+  it('uses ZipFile.OpenRead for entry validation before extraction', function() {
+    const src = mod._EXTRACT_ZIP_PS1;
+    assert.match(src, /ZipFile\]::OpenRead/,
+      'script must enumerate entries via System.IO.Compression.ZipFile');
+    assert.match(src, /parent-traversal/,
+      'script must reject parent-traversal entries');
+    assert.match(src, /absolute/i,
+      'script must reject absolute entries');
+  });
+
+  it('does not use Expand-Archive (which is permissive)', function() {
+    const src = mod._EXTRACT_ZIP_PS1;
+    assert.doesNotMatch(src, /Expand-Archive/,
+      'script must not fall back to Expand-Archive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExtractZipToScratch (Windows-only): path with spaces in tmpdir
+// ---------------------------------------------------------------------------
+
+describe('extractZipToScratch handles paths with spaces', function() {
+  it('extracts a zip when tmpdir contains spaces', { skip: process.platform !== 'win32' }, async function() {
+    // Create a tmpdir whose NAME has spaces, and point os.tmpdir() at it.
+    const spacedParent = fs.mkdtempSync(path.join(os.tmpdir(), 'agnx spaced '));
+    const origTmpdir = os.tmpdir;
+    os.tmpdir = function() { return spacedParent; };
+    try {
+      // Build a minimal zip in memory. Use Node's zlib? There's no stdlib
+      // zip builder. Fall back to creating a zip via PowerShell itself.
+      const seed = fs.mkdtempSync(path.join(spacedParent, 'seed-'));
+      const payload = path.join(seed, 'agent-analyzer.exe');
+      fs.writeFileSync(payload, 'fake binary\r\n');
+      const zipOut = path.join(spacedParent, 'in put.zip');
+      const r = cp.spawnSync('powershell.exe', [
+        '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+        '-Command',
+        'Compress-Archive -LiteralPath $env:SRC -DestinationPath $env:DST -Force'
+      ], {
+        env: Object.assign({}, process.env, { SRC: payload, DST: zipOut }),
+        windowsHide: true
+      });
+      assert.equal(r.status, 0, 'zip builder failed: ' + (r.stderr && r.stderr.toString()));
+
+      const buf = fs.readFileSync(zipOut);
+      const scratch = await mod.extractZipToScratch(buf);
+      try {
+        const extracted = path.join(scratch, 'agent-analyzer.exe');
+        assert.ok(fs.existsSync(extracted), 'binary should extract despite spaces in tmpdir');
+      } finally {
+        fs.rmSync(scratch, { recursive: true, force: true });
+      }
+    } finally {
+      os.tmpdir = origTmpdir;
+      fs.rmSync(spacedParent, { recursive: true, force: true });
+    }
+  });
+
+  it('cleans up scratch when extraction fails', { skip: process.platform !== 'win32' }, async function() {
+    const before = fs.readdirSync(os.tmpdir()).filter(function(n) {
+      return n.startsWith('agent-analyzer-zip-');
+    });
+    await assert.rejects(function() {
+      // A buffer that is not a zip will make PowerShell exit non-zero.
+      return mod.extractZipToScratch(Buffer.from('not a zip file'));
+    });
+    const after = fs.readdirSync(os.tmpdir()).filter(function(n) {
+      return n.startsWith('agent-analyzer-zip-');
+    });
+    assert.deepEqual(after.sort(), before.sort(),
+      'extractZipToScratch must not leak scratch dirs on failure');
+  });
+});

--- a/lib/binary/version.js
+++ b/lib/binary/version.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// Minimum binary version required by this version of agent-core
+const ANALYZER_MIN_VERSION = '0.3.0';
+
+// Binary name
+const BINARY_NAME = 'agent-analyzer';
+
+// GitHub repo for releases
+const GITHUB_REPO = 'agent-sh/agent-analyzer';
+
+module.exports = {
+  ANALYZER_MIN_VERSION,
+  BINARY_NAME,
+  GITHUB_REPO
+};

--- a/lib/collectors/docs-patterns.js
+++ b/lib/collectors/docs-patterns.js
@@ -13,47 +13,33 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
-// Lazy-load the repo-intel artifact loader (still named `repo-map`
-// upstream in agentsys/lib for historical reasons - it produces and
-// consumes `repo-intel.json`). The resolver (lib/agentsys) finds the
-// canonical agentsys install, so this plugin no longer ships its own copy.
-let repoIntelModule = null;
-let repoIntelLoadError = null;
+// Lazy-load repo-map to avoid circular dependencies
+let repoMapModule = null;
+let repoMapLoadError = null;
 
 /**
- * Get the repo-intel artifact loader module, loading it lazily via the
- * agentsys resolver. The returned API exposes
- * `exists / load / init / update / checkAstGrepInstalled` (the legacy
- * `repo-map` shape - the underlying file is `repo-intel.json`).
- *
- * @returns {Object|null} The module, or null if agentsys can't be located.
+ * Get the repo-map module, loading it lazily
+ * @returns {{module: Object|null, error: string|null}}
  */
-function getRepoIntel() {
-  if (!repoIntelModule && !repoIntelLoadError) {
+function getRepoMap() {
+  if (!repoMapModule && !repoMapLoadError) {
     try {
-      const { repoMap } = require('../agentsys').get();
-      if (!repoMap) {
-        repoIntelLoadError =
-          'agentsys does not expose a repo-map module (install too old?)';
-      } else {
-        repoIntelModule = repoMap;
-      }
+      repoMapModule = require('../repo-map');
     } catch (err) {
-      repoIntelLoadError = err.message || 'Failed to resolve agentsys';
-      repoIntelModule = null;
+      // Module not found or failed to load - store error for diagnostics
+      repoMapLoadError = err.message || 'Failed to load repo-map module';
+      repoMapModule = null;
     }
   }
-  return repoIntelModule;
+  return repoMapModule;
 }
 
 /**
- * Get the load error for diagnostics. Distinct from a clean "not present"
- * because callers may want to surface "agentsys missing" specifically.
- *
+ * Get the repo-map load error if any
  * @returns {string|null}
  */
-function getRepoIntelLoadError() {
-  return repoIntelLoadError;
+function getRepoMapLoadError() {
+  return repoMapLoadError;
 }
 
 const DEFAULT_OPTIONS = {
@@ -128,7 +114,7 @@ function isEntryPoint(filePath) {
  */
 async function ensureRepoMap(options = {}) {
   const { cwd = process.cwd(), askUser } = options;
-  const repoMap = getRepoIntel();
+  const repoMap = getRepoMap();
   
   // No repo-map module available
   if (!repoMap) {
@@ -198,7 +184,7 @@ async function ensureRepoMap(options = {}) {
  */
 function ensureRepoMapSync(options = {}) {
   const { cwd = process.cwd() } = options;
-  const repoMap = getRepoIntel();
+  const repoMap = getRepoMap();
   
   if (!repoMap) {
     return { available: false, map: null, fallbackReason: 'repo-map-module-not-found' };
@@ -723,8 +709,5 @@ module.exports = {
   // Utilities
   escapeRegex,
   // Diagnostic
-  getRepoIntelLoadError,
-  // Back-compat alias - old callers still imported `getRepoMapLoadError`.
-  // TODO: remove after all callers migrate to `getRepoIntelLoadError`.
-  getRepoMapLoadError: getRepoIntelLoadError
+  getRepoMapLoadError
 };

--- a/lib/collectors/git.js
+++ b/lib/collectors/git.js
@@ -9,15 +9,8 @@
 
 'use strict';
 
-// Resolve the canonical agentsys binary at first call. Lazy so
-// modules other than this one don't pay the lookup cost.
-let binaryModule = null;
-function binary() {
-  if (!binaryModule) {
-    binaryModule = require('../agentsys').get().binary;
-  }
-  return binaryModule;
-}
+const binary = require('../binary');
+
 const DEFAULT_OPTIONS = {
   top: 20,
   adjustForAi: false,
@@ -41,7 +34,7 @@ function collectGitData(options = {}) {
   const cwd = opts.cwd || process.cwd();
 
   try {
-    binary().ensureBinarySync();
+    binary.ensureBinarySync();
   } catch (err) {
     return {
       available: false,
@@ -51,7 +44,7 @@ function collectGitData(options = {}) {
 
   let map;
   try {
-    const json = binary().runAnalyzer(['repo-intel', 'init', cwd]);
+    const json = binary.runAnalyzer(['repo-intel', 'init', cwd]);
     map = JSON.parse(json);
   } catch (err) {
     return {

--- a/lib/drift-detect/collectors.js
+++ b/lib/drift-detect/collectors.js
@@ -3,7 +3,7 @@
  * Pure JavaScript data collection - no LLM needed
  *
  * BACKWARD COMPATIBILITY: This module re-exports from lib/collectors.
- * For new code, use: const { collectors } = require('./lib');
+ * For new code, use: const { collectors } = require('@agentsys/lib');
  *
  * Replaces three LLM agents (issue-scanner, doc-analyzer, code-explorer)
  * with deterministic JavaScript functions.

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,18 +25,12 @@ const customHandler = require('./sources/custom-handler');
 const policyQuestions = require('./sources/policy-questions');
 const crossPlatform = require('./cross-platform');
 const enhance = require('./enhance');
+const repoMap = require('./repo-map');
 const perf = require('./perf');
 const collectors = require('./collectors');
 const discoveryModule = require('./discovery');
-// Resolve the canonical agentsys binary at first call. Lazy so
-// modules other than this one don't pay the lookup cost.
-let binaryModule = null;
-function binary() {
-  if (!binaryModule) {
-    binaryModule = require('../agentsys').get().binary;
-  }
-  return binaryModule;
-}
+const binary = require('./binary');
+
 /**
  * Platform detection and verification utilities
  */
@@ -256,9 +250,12 @@ module.exports = {
   sources,
   xplat,
   enhance,
+  repoMap,
   perf,
   collectors,
   discovery,
+  binary,
+
   // Direct module access for backward compatibility
   detectPlatform,
   verifyTools,

--- a/lib/repo-map/cache.js
+++ b/lib/repo-map/cache.js
@@ -1,0 +1,152 @@
+/**
+ * Repo map cache management
+ *
+ * @module lib/repo-map/cache
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { getStateDirPath } = require('../platform/state-dir');
+const { writeJsonAtomic, writeFileAtomic } = require('../utils/atomic-write');
+
+const MAP_FILENAME = 'repo-map.json';
+const STALE_FILENAME = 'repo-map.stale';
+
+/**
+ * Get repo-map path
+ * @param {string} basePath - Repository root
+ * @returns {string}
+ */
+function getMapPath(basePath) {
+  return path.join(getStateDirPath(basePath), MAP_FILENAME);
+}
+
+/**
+ * Get stale marker path
+ * @param {string} basePath - Repository root
+ * @returns {string}
+ */
+function getStalePath(basePath) {
+  return path.join(getStateDirPath(basePath), STALE_FILENAME);
+}
+
+/**
+ * Ensure state directory exists
+ * @param {string} basePath - Repository root
+ * @returns {string}
+ */
+function ensureStateDir(basePath) {
+  const stateDir = getStateDirPath(basePath);
+  if (!fs.existsSync(stateDir)) {
+    fs.mkdirSync(stateDir, { recursive: true });
+  }
+  return stateDir;
+}
+
+/**
+ * Load repo-map from cache
+ * @param {string} basePath - Repository root
+ * @returns {Object|null}
+ */
+function load(basePath) {
+  const mapPath = getMapPath(basePath);
+  if (!fs.existsSync(mapPath)) return null;
+
+  try {
+    const raw = fs.readFileSync(mapPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save repo-map to cache
+ * @param {string} basePath - Repository root
+ * @param {Object} map - Map object
+ */
+function save(basePath, map) {
+  ensureStateDir(basePath);
+  const mapPath = getMapPath(basePath);
+
+  const output = {
+    ...map,
+    updated: new Date().toISOString()
+  };
+
+  writeJsonAtomic(mapPath, output);
+
+  // Clear stale marker if present
+  clearStale(basePath);
+}
+
+/**
+ * Check if repo-map exists
+ * @param {string} basePath - Repository root
+ * @returns {boolean}
+ */
+function exists(basePath) {
+  return fs.existsSync(getMapPath(basePath));
+}
+
+/**
+ * Mark repo-map as stale
+ * @param {string} basePath - Repository root
+ */
+function markStale(basePath) {
+  ensureStateDir(basePath);
+  writeFileAtomic(getStalePath(basePath), new Date().toISOString());
+}
+
+/**
+ * Clear stale marker
+ * @param {string} basePath - Repository root
+ */
+function clearStale(basePath) {
+  const stalePath = getStalePath(basePath);
+  if (fs.existsSync(stalePath)) {
+    fs.unlinkSync(stalePath);
+  }
+}
+
+/**
+ * Check if stale marker exists
+ * @param {string} basePath - Repository root
+ * @returns {boolean}
+ */
+function isMarkedStale(basePath) {
+  return fs.existsSync(getStalePath(basePath));
+}
+
+/**
+ * Get basic status summary
+ * @param {string} basePath - Repository root
+ * @returns {Object|null}
+ */
+function getStatus(basePath) {
+  const map = load(basePath);
+  if (!map) return null;
+
+  return {
+    generated: map.generated,
+    updated: map.updated,
+    commit: map.git?.commit,
+    branch: map.git?.branch,
+    files: Object.keys(map.files || {}).length,
+    symbols: map.stats?.totalSymbols || 0,
+    languages: map.project?.languages || []
+  };
+}
+
+module.exports = {
+  load,
+  save,
+  exists,
+  getStatus,
+  getMapPath,
+  markStale,
+  clearStale,
+  isMarkedStale
+};

--- a/lib/repo-map/converter.js
+++ b/lib/repo-map/converter.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * Convert agent-analyzer repo-intel.json format to repo-map.json format.
+ *
+ * agent-analyzer outputs: { symbols: { [filePath]: { exports, imports, definitions } } }
+ * repo-map expects:       { files: { [filePath]: { language, symbols, imports } } }
+ *
+ * @module lib/repo-map/converter
+ */
+
+const path = require('path');
+
+const LANGUAGE_BY_EXTENSION = {
+  '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript',
+  '.ts': 'typescript', '.tsx': 'typescript', '.mts': 'typescript', '.cts': 'typescript',
+  '.py': 'python', '.pyw': 'python',
+  '.rs': 'rust',
+  '.go': 'go',
+  '.java': 'java'
+};
+
+// SymbolKind values from agent-analyzer (kebab-case serialized)
+const CLASS_KINDS = new Set(['class', 'struct', 'interface', 'enum', 'impl']);
+const TYPE_KINDS = new Set(['trait', 'type-alias']);
+const FUNCTION_LIKE_KINDS = new Set(['method', 'arrow', 'closure']);
+const CONSTANT_KINDS = new Set(['constant', 'variable', 'const', 'field', 'property']);
+
+function detectLanguage(filePath) {
+  return LANGUAGE_BY_EXTENSION[path.extname(filePath).toLowerCase()] || 'unknown';
+}
+
+function detectLanguagesFromFiles(filePaths) {
+  const langs = new Set();
+  for (const fp of filePaths) {
+    const lang = detectLanguage(fp);
+    if (lang !== 'unknown') langs.add(lang);
+  }
+  return Array.from(langs);
+}
+
+/**
+ * Convert a single file's symbols from repo-intel format to repo-map format.
+ * @param {string} filePath
+ * @param {Object} fileSym - { exports, imports, definitions }
+ * @returns {Object} repo-map file entry
+ */
+function convertFile(filePath, fileSym) {
+  const exportNames = new Set((fileSym.exports || []).map(e => e.name));
+
+  const exports = (fileSym.exports || []).map(e => ({
+    name: e.name,
+    kind: e.kind,
+    line: e.line
+  }));
+
+  const functions = [];
+  const classes = [];
+  const types = [];
+  const constants = [];
+
+  for (const def of fileSym.definitions || []) {
+    const entry = {
+      name: def.name,
+      kind: def.kind,
+      line: def.line,
+      exported: exportNames.has(def.name)
+    };
+    if (def.kind === 'function' || FUNCTION_LIKE_KINDS.has(def.kind)) {
+      functions.push(entry);
+    } else if (CLASS_KINDS.has(def.kind)) {
+      classes.push(entry);
+    } else if (TYPE_KINDS.has(def.kind)) {
+      types.push(entry);
+    } else if (CONSTANT_KINDS.has(def.kind)) {
+      constants.push(entry);
+    } else {
+      // Unknown kind - default to constants for backward compat
+      constants.push(entry);
+    }
+  }
+
+  // agent-analyzer imports: [{ from, names }] → repo-map imports: [{ source, kind, names }]
+  const imports = (fileSym.imports || []).map(imp => ({
+    source: imp.from,
+    kind: 'import',
+    names: imp.names || []
+  }));
+
+  return {
+    language: detectLanguage(filePath),
+    symbols: { exports, functions, classes, types, constants },
+    imports
+  };
+}
+
+/**
+ * Convert a full repo-intel data object to repo-map format.
+ * @param {Object} intel - RepoIntelData from agent-analyzer
+ * @returns {Object} repo-map.json compatible object
+ */
+function convertIntelToRepoMap(intel) {
+  const files = {};
+  let totalSymbols = 0;
+  let totalImports = 0;
+
+  for (const [filePath, fileSym] of Object.entries(intel.symbols || {})) {
+    files[filePath] = convertFile(filePath, fileSym);
+    const s = files[filePath].symbols;
+    totalSymbols += s.functions.length + s.classes.length +
+                    s.types.length + s.constants.length;
+    totalImports += files[filePath].imports.length;
+  }
+
+  return {
+    version: '2.0',
+    generated: intel.generated || new Date().toISOString(),
+    git: intel.git ? { commit: intel.git.analyzedUpTo } : undefined,
+    project: { languages: detectLanguagesFromFiles(Object.keys(files)) },
+    stats: {
+      totalFiles: Object.keys(files).length,
+      totalSymbols,
+      totalImports,
+      errors: []
+    },
+    files
+  };
+}
+
+module.exports = { convertIntelToRepoMap, convertFile, detectLanguage };

--- a/lib/repo-map/index.js
+++ b/lib/repo-map/index.js
@@ -1,0 +1,265 @@
+'use strict';
+
+/**
+ * Repo Map - repository symbol mapping via agent-analyzer
+ *
+ * Uses agent-analyzer for symbol extraction. The binary is auto-downloaded
+ * on first use - no external tool installation required.
+ *
+ * @module lib/repo-map
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const installer = require('./installer');
+const cache = require('./cache');
+const updater = require('./updater');
+const converter = require('./converter');
+const binary = require('../binary');
+const { getStateDirPath } = require('../platform/state-dir');
+const { writeJsonAtomic } = require('../utils/atomic-write');
+
+const REPO_INTEL_FILENAME = 'repo-intel.json';
+
+function getIntelMapPath(basePath) {
+  return path.join(getStateDirPath(basePath), REPO_INTEL_FILENAME);
+}
+
+/**
+ * Initialize a new repo map (full scan)
+ * @param {string} basePath - Repository root path
+ * @param {Object} options - Options
+ * @param {boolean} options.force - Force rebuild even if map exists
+ * @returns {Promise<{success: boolean, map?: Object, error?: string}>}
+ */
+async function init(basePath, options = {}) {
+  const installed = await installer.checkInstalled();
+  if (!installed.found) {
+    return {
+      success: false,
+      error: 'agent-analyzer binary unavailable: ' + (installed.error || 'unknown error'),
+      installSuggestion: installer.getInstallInstructions()
+    };
+  }
+
+  const existing = cache.load(basePath);
+  if (existing && !options.force) {
+    return {
+      success: false,
+      error: 'Repo map already exists. Use --force to rebuild or /repo-map update to refresh.',
+      existing: cache.getStatus(basePath)
+    };
+  }
+
+  const startTime = Date.now();
+
+  let intelJson;
+  try {
+    intelJson = await binary.runAnalyzerAsync(['repo-intel', 'init', basePath]);
+  } catch (e) {
+    return {
+      success: false,
+      error: 'agent-analyzer repo-intel init failed: ' + e.message
+    };
+  }
+
+  let intel;
+  try {
+    intel = JSON.parse(intelJson);
+  } catch (e) {
+    return {
+      success: false,
+      error: 'Failed to parse repo-intel output: ' + e.message
+    };
+  }
+
+  // Persist repo-intel.json for future incremental updates
+  const intelPath = getIntelMapPath(basePath);
+  try {
+    writeJsonAtomic(intelPath, intel);
+  } catch {
+    // Non-fatal: update() will fall back to full init
+  }
+
+  const map = converter.convertIntelToRepoMap(intel);
+  map.stats.scanDurationMs = Date.now() - startTime;
+  cache.save(basePath, map);
+
+  return {
+    success: true,
+    map,
+    summary: {
+      files: Object.keys(map.files).length,
+      symbols: map.stats.totalSymbols,
+      languages: map.project.languages,
+      duration: map.stats.scanDurationMs
+    }
+  };
+}
+
+/**
+ * Update an existing repo map (incremental via agent-analyzer)
+ * @param {string} basePath - Repository root path
+ * @param {Object} options - Options
+ * @param {boolean} options.full - Force full rebuild instead of incremental
+ * @returns {Promise<{success: boolean, summary?: Object, error?: string}>}
+ */
+async function update(basePath, options = {}) {
+  const installed = await installer.checkInstalled();
+  if (!installed.found) {
+    return {
+      success: false,
+      error: 'agent-analyzer binary unavailable: ' + (installed.error || 'unknown error'),
+      installSuggestion: installer.getInstallInstructions()
+    };
+  }
+
+  if (!cache.exists(basePath)) {
+    return {
+      success: false,
+      error: 'No repo map found. Run /repo-map init first.'
+    };
+  }
+
+  if (options.full) {
+    return init(basePath, { force: true });
+  }
+
+  const intelPath = getIntelMapPath(basePath);
+  if (!fs.existsSync(intelPath)) {
+    return init(basePath, { force: true });
+  }
+
+  const startTime = Date.now();
+
+  let intelJson;
+  try {
+    intelJson = await binary.runAnalyzerAsync([
+      'repo-intel', 'update',
+      '--map-file', intelPath,
+      basePath
+    ]);
+  } catch (e) {
+    return {
+      success: false,
+      error: 'agent-analyzer repo-intel update failed: ' + e.message
+    };
+  }
+
+  let intel;
+  try {
+    intel = JSON.parse(intelJson);
+  } catch (e) {
+    return {
+      success: false,
+      error: 'Failed to parse repo-intel update output: ' + e.message
+    };
+  }
+
+  try {
+    writeJsonAtomic(intelPath, intel);
+  } catch {
+    // Non-fatal
+  }
+
+  const map = converter.convertIntelToRepoMap(intel);
+  map.stats.scanDurationMs = Date.now() - startTime;
+  cache.save(basePath, map);
+
+  return {
+    success: true,
+    map,
+    summary: {
+      files: Object.keys(map.files).length,
+      symbols: map.stats.totalSymbols,
+      duration: map.stats.scanDurationMs
+    }
+  };
+}
+
+/**
+ * Get repo map status
+ * @param {string} basePath - Repository root path
+ * @returns {{exists: boolean, status?: Object}}
+ */
+function status(basePath) {
+  const map = cache.load(basePath);
+  if (!map) {
+    return { exists: false };
+  }
+
+  const staleness = updater.checkStaleness(basePath, map);
+
+  let branch;
+  try {
+    branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: basePath, encoding: 'utf8' }).trim();
+  } catch {
+    // Non-fatal
+  }
+
+  return {
+    exists: true,
+    status: {
+      generated: map.generated,
+      updated: map.updated,
+      commit: map.git?.commit,
+      branch,
+      files: Object.keys(map.files).length,
+      symbols: map.stats?.totalSymbols || 0,
+      languages: map.project?.languages || [],
+      staleness
+    }
+  };
+}
+
+/**
+ * Load repo map (if exists)
+ * @param {string} basePath - Repository root path
+ * @returns {Object|null}
+ */
+function load(basePath) {
+  return cache.load(basePath);
+}
+
+/**
+ * Check if repo map exists
+ * @param {string} basePath - Repository root path
+ * @returns {boolean}
+ */
+function exists(basePath) {
+  return cache.exists(basePath);
+}
+
+/**
+ * Check if agent-analyzer is available (compat alias for checkInstalled).
+ * Previously checked ast-grep; now checks agent-analyzer.
+ * @returns {Promise<{found: boolean, version?: string, tool: string}>}
+ */
+async function checkAstGrepInstalled() {
+  return installer.checkInstalled();
+}
+
+/**
+ * Get install instructions (compat alias).
+ * @returns {string}
+ */
+function getInstallInstructions() {
+  return installer.getInstallInstructions();
+}
+
+module.exports = {
+  init,
+  update,
+  status,
+  load,
+  exists,
+  checkAstGrepInstalled,
+  getInstallInstructions,
+
+  // Re-export submodules for advanced usage
+  installer,
+  cache,
+  updater
+};

--- a/lib/repo-map/installer.js
+++ b/lib/repo-map/installer.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * agent-analyzer binary availability check.
+ *
+ * Replaces the former ast-grep installer. The agent-analyzer binary is
+ * auto-downloaded by agent-core on first use - no manual install required.
+ *
+ * @module lib/repo-map/installer
+ */
+
+const binary = require('../binary');
+
+/**
+ * Check if agent-analyzer is available (async). Downloads if missing.
+ * @returns {Promise<{found: boolean, version?: string, tool: string}>}
+ */
+async function checkInstalled() {
+  if (binary.isAvailable()) {
+    return { found: true, version: binary.getVersion(), tool: 'agent-analyzer' };
+  }
+  try {
+    await binary.ensureBinary();
+    return { found: true, version: binary.getVersion(), tool: 'agent-analyzer' };
+  } catch (e) {
+    return { found: false, error: e.message, tool: 'agent-analyzer' };
+  }
+}
+
+/**
+ * Check if agent-analyzer is available (sync). Downloads if missing.
+ * @returns {{found: boolean, version?: string, tool: string}}
+ */
+function checkInstalledSync() {
+  if (binary.isAvailable()) {
+    return { found: true, version: binary.getVersion(), tool: 'agent-analyzer' };
+  }
+  try {
+    binary.ensureBinarySync();
+    return { found: true, version: binary.getVersion(), tool: 'agent-analyzer' };
+  } catch (e) {
+    return { found: false, error: e.message, tool: 'agent-analyzer' };
+  }
+}
+
+/**
+ * Version check is handled by the binary module - always true when found.
+ * @returns {boolean}
+ */
+function meetsMinimumVersion() {
+  return true;
+}
+
+/**
+ * Get install instructions (binary is auto-downloaded, but here for compat).
+ * @returns {string}
+ */
+function getInstallInstructions() {
+  return 'agent-analyzer is downloaded automatically on first use from https://github.com/agent-sh/agent-analyzer/releases';
+}
+
+/**
+ * Get minimum version string.
+ * @returns {string}
+ */
+function getMinimumVersion() {
+  return '0.3.0';
+}
+
+module.exports = {
+  checkInstalled,
+  checkInstalledSync,
+  meetsMinimumVersion,
+  getInstallInstructions,
+  getMinimumVersion,
+  // Stub: runner.js references this but is no longer the scan path
+  getCommand: () => null
+};

--- a/lib/repo-map/updater.js
+++ b/lib/repo-map/updater.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Repo map staleness checker.
+ *
+ * Determines whether a cached repo-map is stale relative to the current git HEAD.
+ * The incremental update path is handled by agent-analyzer (repo-intel update).
+ *
+ * @module lib/repo-map/updater
+ */
+
+const { execFileSync } = require('child_process');
+
+const cache = require('./cache');
+
+/**
+ * Check whether the cached map is stale
+ * @param {string} basePath - Repository root path
+ * @param {Object} map - Cached repo map
+ * @returns {{isStale: boolean, reason: string|null, commitsBehind: number, suggestFullRebuild: boolean}}
+ */
+function checkStaleness(basePath, map) {
+  const result = {
+    isStale: false,
+    reason: null,
+    commitsBehind: 0,
+    suggestFullRebuild: false
+  };
+
+  if (!map?.git?.commit) {
+    result.isStale = true;
+    result.reason = 'Missing base commit in repo-map';
+    result.suggestFullRebuild = true;
+    return result;
+  }
+
+  if (cache.isMarkedStale(basePath)) {
+    result.isStale = true;
+    result.reason = 'Marked stale by hook';
+  }
+
+  if (!commitExists(basePath, map.git.commit)) {
+    result.isStale = true;
+    result.reason = 'Base commit no longer exists (rebased?)';
+    result.suggestFullRebuild = true;
+    return result;
+  }
+
+  const currentBranch = getCurrentBranch(basePath);
+  if (currentBranch && map.git.branch && currentBranch !== map.git.branch) {
+    result.isStale = true;
+    result.reason = `Branch changed from ${map.git.branch} to ${currentBranch}`;
+    result.suggestFullRebuild = true;
+  }
+
+  const commitsBehind = getCommitsBehind(basePath, map.git.commit);
+  if (commitsBehind > 0) {
+    result.isStale = true;
+    result.commitsBehind = commitsBehind;
+    if (!result.reason) {
+      result.reason = `${commitsBehind} commits behind HEAD`;
+    }
+  }
+
+  return result;
+}
+
+function isValidCommitHash(commit) {
+  return typeof commit === 'string' && /^[0-9a-fA-F]{4,40}$/.test(commit);
+}
+
+function commitExists(basePath, commit) {
+  if (!isValidCommitHash(commit)) return false;
+  try {
+    execFileSync('git', ['cat-file', '-e', commit], { cwd: basePath, stdio: ['pipe', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getCurrentBranch(basePath) {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: basePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function getCommitsBehind(basePath, commit) {
+  if (!isValidCommitHash(commit)) return 0;
+  try {
+    const out = execFileSync('git', ['rev-list', `${commit}..HEAD`, '--count'], {
+      cwd: basePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    return Number(out) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+module.exports = { checkStaleness };


### PR DESCRIPTION
Automated sync of lib/ and CLAUDE.md from [agent-core](https://github.com/agent-sh/agent-core).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new runtime download/extract logic for executing a GitHub-released binary and rewires collectors to use it, which impacts tool execution paths and introduces network/file-system side effects. Security hardening mitigates tampering and path-traversal risks, but failures could block repo analysis on first run.
> 
> **Overview**
> Introduces a vendored `lib/binary` module that **lazy-downloads `agent-analyzer` at runtime** (no postinstall), now with **SHA-256 sidecar verification**, hardened archive extraction (path-traversal/absolute-path rejection, scratch extraction, symlink defense), and a Windows-specific PowerShell zip extractor that avoids command-string parsing issues.
> 
> Adds a new first-party `lib/repo-map` implementation backed by `agent-analyzer` (`repo-intel init/update`) with caching, staleness tracking, and conversion to `repo-map.json`, and updates collectors/exports to use the local `binary` + `repoMap` modules (replacing prior `agentsys` resolver usage in `git` and `docs-patterns`).
> 
> Includes comprehensive unit tests for checksum parsing/verification, archive safety checks, scratch cleanup, and Windows zip extraction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fa98ea59c434e44c10bbdbc3644a514a45e410. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->