### PR TITLE
fix(agentsys-resolver): prefer plugin's own vendored lib/ (fixes CI)

### DIFF
--- a/lib/agentsys.js
+++ b/lib/agentsys.js
@@ -7,6 +7,7 @@
  * were previously synced from agentsys via agent-core.
  *
  * Lookup order:
+ *   0. __dirname                                       (this plugin's own vendored lib/)
  *   1. ~/.claude/plugins/marketplaces/agentsys/lib    (CC marketplace clone)
  *   2. <npm-global-root>/agentsys/lib                  (npm install -g agentsys)
  *   3. require.resolve('agentsys/lib/package.json')    (project-local install)
@@ -56,6 +57,13 @@ function npmGlobalRoot() {
 function candidatePaths() {
   const home = os.homedir();
   const candidates = [
+    // 0. This plugin's OWN vendored lib/. The sync still ships lib/binary/
+    //    (and friends) into every plugin, so the resolver's own directory
+    //    already satisfies the binary/index.js contract. Preferring it means
+    //    the plugin is self-sufficient - works in bare CI and offline, with no
+    //    external agentsys install - and the external lookups below stay as
+    //    fallbacks for hosts that intentionally share a central agentsys.
+    __dirname,
     path.join(home, '.claude', 'plugins', 'marketplaces', 'agentsys', 'lib'),
   ];
 


### PR DESCRIPTION
Same resolver fix as enhance#33: `findAgentsysLib()` only searched external agentsys installs, failing bare CI. Added `__dirname` (own vendored lib/) as candidate 0. 7/7 tests pass.