### PR TITLE
ci(security): add least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: agent-sh/.github/.github/workflows/ci-node.yml@main


### PR DESCRIPTION
Resolves the CodeQL `actions/missing-workflow-permissions` alerts (ci.yml jobs lacked an explicit `permissions` block). Adds top-level `permissions: contents: read`. The reusable workflows it calls (`agent-sh/.github` ci-node / ci-agnix) already declare `contents: read`, so this is the correct minimal grant - no behavior change. YAML validated.